### PR TITLE
Add support for wp-content folders outside of the wordpress root

### DIFF
--- a/redux-vendor-support.php
+++ b/redux-vendor-support.php
@@ -21,9 +21,9 @@
 
 
 	// Exit if accessed directly
-    if ( ! defined( 'ABSPATH' ) ) {
-        die;
-    }
+	if ( ! defined( 'ABSPATH' ) ) {
+		die;
+	}
 	
 	// The full path to the plugin directory (ends with trailing slash)
 	if( !defined('REDUX_VENDOR_SUPPORT_PLUGIN_DIR') ) define( 'REDUX_VENDOR_SUPPORT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
@@ -31,9 +31,9 @@
 	// The full url to the plugin directory (ends with trailing slash)
 	if( !defined('REDUX_VENDOR_SUPPORT_PLUGIN_URL') ) define( 'REDUX_VENDOR_SUPPORT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 	
-    if ( ! class_exists( 'ReduxFramework_extension_vendor_support' ) ) {
-        if ( file_exists( dirname( __FILE__ ) . '/vendor_support/extension_vendor_support.php' ) ) {
-            require dirname( __FILE__ ) . '/vendor_support/extension_vendor_support.php';
-            new ReduxFramework_extension_vendor_support( null, REDUX_VENDOR_SUPPORT_PLUGIN_DIR, REDUX_VENDOR_SUPPORT_PLUGIN_URL );
-        }
-    }
+	if ( ! class_exists( 'ReduxFramework_extension_vendor_support' ) ) {
+		if ( file_exists( dirname( __FILE__ ) . '/vendor_support/extension_vendor_support.php' ) ) {
+			require dirname( __FILE__ ) . '/vendor_support/extension_vendor_support.php';
+ 			new ReduxFramework_extension_vendor_support( null, REDUX_VENDOR_SUPPORT_PLUGIN_DIR, REDUX_VENDOR_SUPPORT_PLUGIN_URL );
+		}
+	}

--- a/redux-vendor-support.php
+++ b/redux-vendor-support.php
@@ -32,8 +32,13 @@
 	if( !defined('REDUX_VENDOR_SUPPORT_PLUGIN_URL') ) define( 'REDUX_VENDOR_SUPPORT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 	
 	if ( ! class_exists( 'ReduxFramework_extension_vendor_support' ) ) {
+		
 		if ( file_exists( dirname( __FILE__ ) . '/vendor_support/extension_vendor_support.php' ) ) {
+		
 			require dirname( __FILE__ ) . '/vendor_support/extension_vendor_support.php';
+ 		
  			new ReduxFramework_extension_vendor_support( null, REDUX_VENDOR_SUPPORT_PLUGIN_DIR, REDUX_VENDOR_SUPPORT_PLUGIN_URL );
+		
 		}
+		
 	}

--- a/redux-vendor-support.php
+++ b/redux-vendor-support.php
@@ -19,14 +19,21 @@
      * @copyright       2012-2015 Redux Framework
      */
 
-// Exit if accessed directly
+
+	// Exit if accessed directly
     if ( ! defined( 'ABSPATH' ) ) {
         die;
     }
-
+	
+	// The full path to the plugin directory (ends with trailing slash)
+	if( !defined('REDUX_VENDOR_SUPPORT_PLUGIN_DIR') ) define( 'REDUX_VENDOR_SUPPORT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+	
+	// The full url to the plugin directory (ends with trailing slash)
+	if( !defined('REDUX_VENDOR_SUPPORT_PLUGIN_URL') ) define( 'REDUX_VENDOR_SUPPORT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+	
     if ( ! class_exists( 'ReduxFramework_extension_vendor_support' ) ) {
         if ( file_exists( dirname( __FILE__ ) . '/vendor_support/extension_vendor_support.php' ) ) {
             require dirname( __FILE__ ) . '/vendor_support/extension_vendor_support.php';
-            new ReduxFramework_extension_vendor_support();
+            new ReduxFramework_extension_vendor_support( null, REDUX_VENDOR_SUPPORT_PLUGIN_DIR, REDUX_VENDOR_SUPPORT_PLUGIN_URL );
         }
     }

--- a/vendor_support/extension_vendor_support.php
+++ b/vendor_support/extension_vendor_support.php
@@ -56,9 +56,9 @@
 				
 				$this->extension_url = ( !is_null( $extension_url ) ? $extension_url : '' ) . self::$vendor_dir . '/';
 				
-				Redux_VendorURL::$dir = apply_filters('redux_vendor_support_dir', $this->extension_dir );
+				Redux_VendorURL::$dir = apply_filters( 'redux_vendor_support_dir', $this->extension_dir );
                 
-				Redux_VendorURL::$url = apply_filters('redux_vendor_support_url', $this->extension_url );
+				Redux_VendorURL::$url = apply_filters( 'redux_vendor_support_url', $this->extension_url );
 				
 			}
 		} // class

--- a/vendor_support/extension_vendor_support.php
+++ b/vendor_support/extension_vendor_support.php
@@ -34,6 +34,8 @@
 
             static $version = "1.0.0";
 
+			static $vendor_dir = "vendor_support";
+			
             /**
              * Class Constructor. Defines the args for the extions class
              *
@@ -46,16 +48,18 @@
              *
              * @return      void
              */
-            public function __construct( $parent = null ) {
-                if ( empty( $this->extension_dir ) ) {
-                    $this->extension_dir = trailingslashit( str_replace( '\\', '/', dirname( __FILE__ ) ) );
-                    $this->extension_url = site_url( str_replace( trailingslashit( str_replace( '\\', '/', ABSPATH ) ), '', $this->extension_dir ) );
-                }
+            public function __construct( $parent = null, $extension_dir = null, $extension_url= null ) {
+				
+                include_once $extension_dir . self::$vendor_dir . DIRECTORY_SEPARATOR . 'class.vendor-url.php';
 
-                include_once $this->extension_dir . 'class.vendor-url.php';
-
-                Redux_VendorURL::$dir = $this->extension_dir;
-                Redux_VendorURL::$url = $this->extension_url;
+				$this->extension_dir = ( !is_null( $extension_dir ) ? $extension_dir : '' ) . self::$vendor_dir . DIRECTORY_SEPARATOR;
+				
+				$this->extension_url = ( !is_null( $extension_url ) ? $extension_url : '' ) . self::$vendor_dir . '/';
+				
+                Redux_VendorURL::$dir = apply_filters('redux_vendor_support_dir', $this->extension_dir );
+                
+				Redux_VendorURL::$url = apply_filters('redux_vendor_support_url', $this->extension_url );
+				
             }
         } // class
     } // if

--- a/vendor_support/extension_vendor_support.php
+++ b/vendor_support/extension_vendor_support.php
@@ -17,22 +17,22 @@
      * @version     3.0.0
      */
 
-// Exit if accessed directly
-    if ( ! defined( 'ABSPATH' ) ) {
-        exit;
-    }
+	// Exit if accessed directly
+	if ( ! defined( 'ABSPATH' ) ) {
+		exit;
+	}
 
-// Don't duplicate me!
-    if ( ! class_exists( 'ReduxFramework_extension_vendor_support' ) ) {
+	// Don't duplicate me!
+	if ( ! class_exists( 'ReduxFramework_extension_vendor_support' ) ) {
 
         /**
          * Main ReduxFramework custom_field extension class
          *
          * @since       3.1.6
          */
-        class ReduxFramework_extension_vendor_support {
+		class ReduxFramework_extension_vendor_support {
 
-            static $version = "1.0.0";
+			static $version = "1.0.0";
 
 			static $vendor_dir = "vendor_support";
 			
@@ -50,16 +50,16 @@
              */
             public function __construct( $parent = null, $extension_dir = null, $extension_url= null ) {
 				
-                include_once $extension_dir . self::$vendor_dir . DIRECTORY_SEPARATOR . 'class.vendor-url.php';
+				include_once $extension_dir . self::$vendor_dir . DIRECTORY_SEPARATOR . 'class.vendor-url.php';
 
 				$this->extension_dir = ( !is_null( $extension_dir ) ? $extension_dir : '' ) . self::$vendor_dir . DIRECTORY_SEPARATOR;
 				
 				$this->extension_url = ( !is_null( $extension_url ) ? $extension_url : '' ) . self::$vendor_dir . '/';
 				
-                Redux_VendorURL::$dir = apply_filters('redux_vendor_support_dir', $this->extension_dir );
+				Redux_VendorURL::$dir = apply_filters('redux_vendor_support_dir', $this->extension_dir );
                 
 				Redux_VendorURL::$url = apply_filters('redux_vendor_support_url', $this->extension_url );
 				
-            }
-        } // class
-    } // if
+			}
+		} // class
+	} // if


### PR DESCRIPTION
Better support for the wp-content folder being used outside of the wordpress root. Vendor directory and url are relative to the plugin root, rather than performing str_replace which does not cover all cases across linux and windows. Added additional filters to the vendor directory and url to allow flexibility for user plugins. 
