### PR TITLE
Add more accurate detection of the vendor directory and vendor url

### DIFF
--- a/redux-vendor-support.php
+++ b/redux-vendor-support.php
@@ -19,7 +19,7 @@
      * @copyright       2012-2015 Redux Framework
      */
 
-// Exit if accessed directly
+    // Exit if accessed directly
     if ( ! defined( 'ABSPATH' ) ) {
         die;
     }
@@ -27,6 +27,6 @@
     if ( ! class_exists( 'ReduxFramework_extension_vendor_support' ) ) {
         if ( file_exists( dirname( __FILE__ ) . '/vendor_support/extension_vendor_support.php' ) ) {
             require dirname( __FILE__ ) . '/vendor_support/extension_vendor_support.php';
-            new ReduxFramework_extension_vendor_support();
+            new ReduxFramework_extension_vendor_support( null, plugin_dir_path( __FILE__ ), plugin_dir_url( __FILE__ ) );
         }
     }

--- a/vendor_support/extension_vendor_support.php
+++ b/vendor_support/extension_vendor_support.php
@@ -17,12 +17,12 @@
      * @version     3.0.0
      */
 
-// Exit if accessed directly
+    // Exit if accessed directly
     if ( ! defined( 'ABSPATH' ) ) {
         exit;
     }
 
-// Don't duplicate me!
+    // Don't duplicate me!
     if ( ! class_exists( 'ReduxFramework_extension_vendor_support' ) ) {
 
         /**
@@ -34,28 +34,32 @@
 
             static $version = "1.0.0";
 
+            static $vendor_dir = "vendor_support";
+
             /**
              * Class Constructor. Defines the args for the extions class
              *
              * @since       1.0.0
              * @access      public
              *
-             * @param       array $sections   Panel sections.
-             * @param       array $args       Class constructor arguments.
-             * @param       array $extra_tabs Extra panel tabs.
+             * @param       mixed $parent Panel sections.
+             * @param       string $extension_dir Extension Directory.
+             * @param       string $extension_url Extension Url.
              *
              * @return      void
              */
-            public function __construct( $parent = null ) {
-                if ( empty( $this->extension_dir ) ) {
-                    $this->extension_dir = trailingslashit( str_replace( '\\', '/', dirname( __FILE__ ) ) );
-                    $this->extension_url = site_url( str_replace( trailingslashit( str_replace( '\\', '/', ABSPATH ) ), '', $this->extension_dir ) );
-                }
+            public function __construct( $parent = null, $extension_dir = null, $extension_url= null ) {
 
-                include_once $this->extension_dir . 'class.vendor-url.php';
+                include_once $extension_dir . self::$vendor_dir . DIRECTORY_SEPARATOR . 'class.vendor-url.php';
 
-                Redux_VendorURL::$dir = $this->extension_dir;
-                Redux_VendorURL::$url = $this->extension_url;
+                $this->extension_dir = ( !is_null( $extension_dir ) ? $extension_dir : '' ) . self::$vendor_dir . DIRECTORY_SEPARATOR;
+
+                $this->extension_url = ( !is_null( $extension_url ) ? $extension_url : '' ) . self::$vendor_dir . '/';
+
+                Redux_VendorURL::$dir = apply_filters( 'redux_vendor_support_dir', $this->extension_dir );
+
+                Redux_VendorURL::$url = apply_filters( 'redux_vendor_support_url', $this->extension_url );
+
             }
         } // class
     } // if


### PR DESCRIPTION
Add more accurate detection of the vendor directory and vendor url by using wordpress functions plugin_dir_path() and plugin_dir_url(). This ensures compatibility on windows and linux, as well as cases where the wp-content may not live in the wordpress root directory. Applied filters to dir and url to support modifications by third-party plugins.
